### PR TITLE
Centralize alert configuration

### DIFF
--- a/index.php
+++ b/index.php
@@ -86,6 +86,7 @@ $voteAgg = [];
     const isLoggedIn = <?= $userId ? 'true' : 'false' ?>;
     const csrfToken = '<?= $_SESSION['csrf_token'] ?>';
   </script>
+  <script src="js/alerts.js"></script>
   <script src="js/script.js"></script>
   <script src="js/search.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -1,0 +1,166 @@
+// alerts.js - centralized Bootstrap alert helpers and configuration
+
+const AlertsConfig = {
+  loginRequired: {
+    text: 'You must be logged in to vote!',
+    type: 'warning'
+  },
+  rateLimit: {
+    text: "You're voting too fast! Please wait a moment.",
+    type: 'primary'
+  },
+  submitError: {
+    text: 'Error submitting vote.',
+    type: 'warning'
+  },
+  networkError: {
+    text: 'Network error. Please try again.',
+    type: 'warning'
+  },
+  modalInvalidEmail: {
+    text: 'Please enter a valid email address above first.',
+    type: 'warning'
+  },
+  modalGmailReset: {
+    text: 'You cannot reset the password of a Gmail account using this form.',
+    type: 'danger'
+  },
+  modalResetSent: {
+    text: 'If the email address is registered, please check your inbox for a link to reset your password.',
+    type: 'success'
+  },
+  modalGmailLogin: {
+    text: 'You cannot log in or register with a Gmail account using this form. Please use the "Continue with Google" button above.',
+    type: 'warning'
+  }
+};
+
+function buildAlertConfig(keyOrOptions, overrides = {}) {
+  const base = typeof keyOrOptions === 'string'
+    ? (AlertsConfig[keyOrOptions] || { text: keyOrOptions })
+    : keyOrOptions;
+  const cfg = Object.assign({
+    text: '',
+    type: 'danger',
+    fade: true,
+    dismissible: true,
+    autoDismiss: true,
+    timeout: 5000
+  }, base, overrides);
+  return cfg;
+}
+
+// ------- Toast-style alert -------
+let currentAlert = null;
+let alertTimer   = null;
+function showAlert(key, overrides = {}) {
+  const cfg = buildAlertConfig(key, overrides);
+  const container = document.getElementById('alert-container');
+  if (!container) return;
+
+  if (currentAlert) {
+    currentAlert.remove();
+    clearTimeout(alertTimer);
+    currentAlert = null;
+  }
+
+  const alertDiv = document.createElement('div');
+  alertDiv.classList.add('alert', `alert-${cfg.type}`);
+  if (cfg.dismissible) alertDiv.classList.add('alert-dismissible');
+  if (cfg.fade) alertDiv.classList.add('fade');
+  alertDiv.setAttribute('role', 'alert');
+  alertDiv.setAttribute('data-bs-theme', 'dark');
+  alertDiv.innerHTML = cfg.dismissible
+    ? `<span class="alert-body">${cfg.text}</span><button type="button" class="btn-close btn-close-white" aria-label="Close"></button>`
+    : `<span class="alert-body">${cfg.text}</span>`;
+  container.append(alertDiv);
+  currentAlert = alertDiv;
+
+  if (cfg.fade) requestAnimationFrame(() => alertDiv.classList.add('show'));
+
+  function remove() {
+    if (alertDiv.parentElement) alertDiv.remove();
+    if (currentAlert === alertDiv) currentAlert = null;
+  }
+
+  function dismiss() {
+    if (cfg.fade) {
+      alertDiv.classList.remove('show');
+      alertDiv.addEventListener('transitionend', remove, { once: true });
+    } else {
+      remove();
+    }
+    clearTimeout(alertTimer);
+  }
+
+  if (cfg.dismissible) {
+    alertDiv.querySelector('.btn-close').addEventListener('click', dismiss);
+  }
+
+  if (cfg.autoDismiss) {
+    alertTimer = setTimeout(dismiss, cfg.timeout);
+  }
+}
+
+// ------- Modal relative alert -------
+let currentModalAlert = null;
+let modalAlertTimer   = null;
+function showModalAlert(key, overrides = {}) {
+  const cfg = buildAlertConfig(key, overrides);
+
+  if (currentModalAlert) {
+    currentModalAlert.remove();
+    clearTimeout(modalAlertTimer);
+    currentModalAlert = null;
+  }
+
+  const dialog = document.querySelector('#authModal .modal-dialog');
+  if (!dialog) return;
+  const rect = dialog.getBoundingClientRect();
+
+  const alertDiv = document.createElement('div');
+  alertDiv.classList.add('alert', `alert-${cfg.type}`);
+  if (cfg.dismissible) alertDiv.classList.add('alert-dismissible');
+  if (cfg.fade) alertDiv.classList.add('fade');
+  alertDiv.setAttribute('role', 'alert');
+  alertDiv.setAttribute('data-bs-theme', 'dark');
+  alertDiv.style.position = 'absolute';
+  alertDiv.style.top      = `${rect.bottom + 8}px`;
+  alertDiv.style.left     = `${rect.left}px`;
+  alertDiv.style.width    = `${rect.width}px`;
+  alertDiv.style.zIndex   = '1060';
+  alertDiv.innerHTML = cfg.dismissible
+    ? `${cfg.text}<button type="button" class="btn-close btn-close-white" aria-label="Close"></button>`
+    : cfg.text;
+  document.body.append(alertDiv);
+  currentModalAlert = alertDiv;
+
+  if (cfg.fade) requestAnimationFrame(() => alertDiv.classList.add('show'));
+
+  function remove() {
+    if (alertDiv.parentElement) alertDiv.remove();
+    currentModalAlert = null;
+  }
+
+  function dismiss() {
+    if (cfg.fade) {
+      alertDiv.classList.remove('show');
+      alertDiv.addEventListener('transitionend', remove, { once: true });
+    } else {
+      remove();
+    }
+    clearTimeout(modalAlertTimer);
+  }
+
+  if (cfg.dismissible) {
+    alertDiv.querySelector('.btn-close').addEventListener('click', dismiss);
+  }
+
+  if (cfg.autoDismiss) {
+    modalAlertTimer = setTimeout(dismiss, cfg.timeout);
+  }
+}
+
+window.AlertsConfig  = AlertsConfig;
+window.showAlert     = showAlert;
+window.showModalAlert = showModalAlert;

--- a/js/script.js
+++ b/js/script.js
@@ -1,110 +1,5 @@
 // script.js
 
-// keep references so we never create more than one
-let currentAlert = null;
-let alertTimer   = null;
-
-function showAlert(message, type = 'danger') {
-  const container = document.getElementById('alert-container');
-  if (!container) return;
-
-  // If already showing, update text & reset timer
-  if (currentAlert) {
-    currentAlert.querySelector('.alert-body').textContent = message;
-    resetTimer();
-    return;
-  }
-
-  // Create the alert with only .fade (no .show yet)
-  const alertDiv = document.createElement('div');
-  alertDiv.className = `alert alert-${type} alert-dismissible fade`;
-  alertDiv.setAttribute('role', 'alert');
-  alertDiv.setAttribute('data-bs-theme', 'dark');
-  alertDiv.innerHTML = `
-    <span class="alert-body">${message}</span>
-    <button type="button" class="btn-close btn-close-white" aria-label="Close"></button>
-  `;
-  container.append(alertDiv);
-  currentAlert = alertDiv;
-
-  // Trigger a reflow, then add .show for fade-in
-  requestAnimationFrame(() => alertDiv.classList.add('show'));
-
-  // Dismiss helper (fade-out then remove)
-  function dismiss() {
-    alertDiv.classList.remove('show');
-    alertDiv.addEventListener('transitionend', () => {
-      if (alertDiv.parentElement) alertDiv.remove();
-      if (currentAlert === alertDiv) currentAlert = null;
-    }, { once: true });
-    clearTimeout(alertTimer);
-  }
-
-  // Wire the × button
-  alertDiv.querySelector('.btn-close').addEventListener('click', dismiss);
-
-  // Auto-dismiss after 5 s
-  function resetTimer() {
-    clearTimeout(alertTimer);
-    alertTimer = setTimeout(dismiss, 5000);
-  }
-  resetTimer();
-}
-
-// ensures only one modal-alert exists at a time
-let currentModalAlert = null;
-let modalAlertTimer   = null;
-
-function showModalAlert(message, type = 'danger') {
-  // If one is already up, dismiss it immediately
-  if (currentModalAlert) {
-    clearTimeout(modalAlertTimer);
-    currentModalAlert.remove();
-    currentModalAlert = null;
-  }
-
-  // find modal-dialog and position
-  const dialog = document.querySelector('#authModal .modal-dialog');
-  if (!dialog) return;
-  const rect = dialog.getBoundingClientRect();
-
-  // create alert DIV with .fade only
-  const alertDiv = document.createElement('div');
-  alertDiv.className = `alert alert-${type} alert-dismissible fade`;
-  alertDiv.setAttribute('role', 'alert');
-  alertDiv.setAttribute('data-bs-theme', 'dark');
-  alertDiv.style.position = 'absolute';
-  alertDiv.style.top      = `${rect.bottom + 8}px`;
-  alertDiv.style.left     = `${rect.left}px`;
-  alertDiv.style.width    = `${rect.width}px`;
-  alertDiv.style.zIndex   = '1060';
-  alertDiv.innerHTML = `
-    ${message}
-    <button type="button" class="btn-close btn-close-white" aria-label="Close"></button>
-  `;
-  document.body.append(alertDiv);
-  currentModalAlert = alertDiv;
-
-  // fade-in
-  requestAnimationFrame(() => alertDiv.classList.add('show'));
-
-  // helper to fade-out then remove
-  function dismiss() {
-    alertDiv.classList.remove('show');
-    alertDiv.addEventListener('transitionend', () => {
-      if (alertDiv.parentElement) alertDiv.remove();
-    }, { once: true });
-    currentModalAlert = null;
-    clearTimeout(modalAlertTimer);
-  }
-
-  // close button wires into dismiss
-  alertDiv.querySelector('.btn-close').addEventListener('click', dismiss);
-
-  // auto-dismiss after 5 s
-  modalAlertTimer = setTimeout(dismiss, 5000);
-}
-
 // Single DOMContentLoaded listener
 document.addEventListener('DOMContentLoaded', () => {
   // 1) Block Gmail addresses on manual login/register
@@ -115,10 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const email = emailInput.value.trim().toLowerCase();
       if (email.endsWith('@gmail.com')) {
         e.preventDefault();
-        showModalAlert(
-          'You cannot log in or register with a Gmail account using this form. Please use the "Continue with Google" button above.',
-          'warning'
-        );
+        showModalAlert('modalGmailLogin');
       }
     });
   }
@@ -131,12 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const email = emailInput.value.trim();
       const validEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
       if (!validEmail) {
-        return showModalAlert('Please enter a valid email address above first.', 'warning');
+        return showModalAlert('modalInvalidEmail');
       }
       if (email.toLowerCase().endsWith('@gmail.com')) {
-        return showModalAlert(
-          'You cannot reset the password of a Gmail account using this form.', 'danger'
-        );
+        return showModalAlert('modalGmailReset');
       }
       // send the reset request
       fetch('forgot_password.php', {
@@ -146,13 +36,10 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .then(res => res.json())
       .then(() => {
-        showModalAlert(
-          'If the email address is registered, please check your inbox for a link to reset your password.',
-          'success'
-        );
+        showModalAlert('modalResetSent');
       })
       .catch(() => {
-        showModalAlert('Network error. Please try again.', 'danger');
+        showModalAlert('networkError', { type: 'danger' });
       });
     });
   }
@@ -172,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
       icon.addEventListener('click', e => {
         e.stopPropagation();
         if (!isLoggedIn) {
-          showAlert('You must be logged in to vote!', 'warning');
+          showAlert('loginRequired');
           return;
         }
         const type      = icon.dataset.voteType;
@@ -191,7 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(res => {
           if (res.status === 429) {
             // Rate-limit hit
-            showAlert("You're voting too fast! Please wait a moment.", 'primary');
+            showAlert('rateLimit');
             throw new Error('rate_limit');
           }
           return res.json();
@@ -199,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(data => {
           if (!data.success) {
             // other errors (e.g. db_error)
-            showAlert(data.error || 'Error submitting vote.', 'warning');
+            showAlert('submitError', { text: data.error || AlertsConfig.submitError.text });
             return;
           }
           // --- success UI update ---
@@ -225,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
           // suppress the thrown rate_limit error
           if (err.message === 'rate_limit') return;
           // network or other exception
-          showAlert('Network error—please try again.', 'warning');
+          showAlert('networkError');
         });
       });
     });    

--- a/js/search.js
+++ b/js/search.js
@@ -28,9 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
       icon.addEventListener('click', e => {
         e.stopPropagation();
         if (!window.isLoggedIn) {
-          if (typeof showAlert === 'function') {
-            showAlert('You must be logged in to vote!', 'warning');
-          }
+          showAlert('loginRequired');
           return;
         }
         const type      = icon.dataset.voteType;
@@ -48,9 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(res => res.status === 429 ? Promise.reject('rate_limit') : res.json())
         .then(data => {
           if (!data.success) {
-            if (typeof showAlert === 'function') {
-              showAlert(data.error || 'Error submitting vote.', 'warning');
-            }
+            showAlert('submitError', { text: data.error || AlertsConfig.submitError.text });
             return;
           }
           const k     = data.kbm;
@@ -73,11 +69,9 @@ document.addEventListener('DOMContentLoaded', () => {
         })
         .catch(err => {
           if (err === 'rate_limit') {
-            if (typeof showAlert === 'function') {
-              showAlert("You're voting too fast! Please wait a moment.", 'primary');
-            }
-          } else if (typeof showAlert === 'function') {
-            showAlert('Network error—please try again.', 'warning');
+            showAlert('rateLimit');
+          } else {
+            showAlert('networkError');
           }
         });
       });


### PR DESCRIPTION
## Summary
- add `alerts.js` with shared configuration for showing Bootstrap alerts
- refactor existing JS to use the shared helpers
- load `alerts.js` before other scripts

## Testing
- `php -l index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a9937ffd4832d93cde16b19809946