### PR TITLE
Centralize alert configuration

### DIFF
--- a/index.php
+++ b/index.php
@@ -89,6 +89,7 @@ $voteAgg = [];
     const isLoggedIn = <?= $userId ? 'true' : 'false' ?>;
     const csrfToken = '<?= $_SESSION['csrf_token'] ?>';
   </script>
+  <script src="js/alertsConfig.js"></script>
   <script src="js/script.js"></script>
   <script src="js/search.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>

--- a/js/alertsConfig.js
+++ b/js/alertsConfig.js
@@ -1,0 +1,75 @@
+// alertsConfig.js - central configuration for Bootstrap alerts
+// Each key defines default properties for a named alert.
+// text: message text
+// type: Bootstrap contextual class suffix
+// fade: whether to fade in/out
+// autoHide: automatically dismiss after timeout (true/false)
+// timeout: milliseconds before auto-dismiss (ignored if autoHide false or 0)
+// dismissible: whether an X button is shown
+
+window.alertConfigs = {
+  notLoggedIn: {
+    text: 'You must be logged in to vote!',
+    type: 'warning',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  rateLimit: {
+    text: "You're voting too fast! Please wait a moment.",
+    type: 'primary',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  submitError: {
+    text: 'Error submitting vote.',
+    type: 'warning',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  networkError: {
+    text: 'Network error—please try again.',
+    type: 'warning',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  gmailAuth: {
+    text: 'You cannot log in or register with a Gmail account using this form. Please use the "Continue with Google" button above.',
+    type: 'warning',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  invalidEmail: {
+    text: 'Please enter a valid email address above first.',
+    type: 'warning',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  gmailReset: {
+    text: 'You cannot reset the password of a Gmail account using this form.',
+    type: 'danger',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  },
+  resetNotice: {
+    text: 'If the email address is registered, please check your inbox for a link to reset your password.',
+    type: 'success',
+    fade: true,
+    autoHide: true,
+    timeout: 5000,
+    dismissible: true
+  }
+};

--- a/js/search.js
+++ b/js/search.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
         e.stopPropagation();
         if (!window.isLoggedIn) {
           if (typeof showAlert === 'function') {
-            showAlert('You must be logged in to vote!', 'warning');
+            showAlert('notLoggedIn');
           }
           return;
         }
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(data => {
           if (!data.success) {
             if (typeof showAlert === 'function') {
-              showAlert(data.error || 'Error submitting vote.', 'warning');
+              showAlert('submitError', { text: data.error || window.alertConfigs.submitError.text });
             }
             return;
           }
@@ -74,10 +74,10 @@ document.addEventListener('DOMContentLoaded', () => {
         .catch(err => {
           if (err === 'rate_limit') {
             if (typeof showAlert === 'function') {
-              showAlert("You're voting too fast! Please wait a moment.", 'primary');
+              showAlert('rateLimit');
             }
           } else if (typeof showAlert === 'function') {
-            showAlert('Network error—please try again.', 'warning');
+            showAlert('networkError');
           }
         });
       });


### PR DESCRIPTION
## Summary
- add `alertsConfig.js` for reusable Bootstrap alert settings
- update alert helper functions to read from config and allow overrides
- load new config on the main page
- use alert IDs in script and search code

## Testing
- `node --check js/script.js`
- `node --check js/search.js`
- `node --check js/alertsConfig.js`

------
https://chatgpt.com/codex/tasks/task_e_686ac0bac0d4832d82bb507786c5171b