### PR TITLE
Centralize alert handling in new JS module

### DIFF
--- a/index.php
+++ b/index.php
@@ -92,6 +92,7 @@ $voteAgg = [];
     const csrfToken = '<?= $_SESSION['csrf_token'] ?>';
     window.csrfToken = csrfToken;
   </script>
+  <script src="js/alerts.js"></script>
   <script src="js/script.js"></script>
   <script src="js/search.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
@@ -221,11 +222,11 @@ function handleCredentialResponse(response) {
       // reload so navbar updates and votes can work
       window.location.reload();
     } else {
-      showModalAlert(data.error || 'Google sign-in failed.', 'danger');
+      Alerts.showModal('googleSigninError', { message: data.error || Alerts.config.googleSigninError.message });
     }
   })
   .catch(() => {
-    showModalAlert('Network error during Google sign-in.', 'danger');
+    Alerts.showModal('googleSigninNetworkError');
   });
 }
 </script>

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -1,0 +1,167 @@
+(function(){
+  const defaultConfig = {
+    message: '',
+    type: 'danger',
+    dismissable: true,
+    autoDismiss: true,
+    timeout: 5000,
+    fade: true
+  };
+
+  const configs = {
+    loginGmailBlock: {
+      message: 'You cannot log in or register with a Gmail account using this form. Please use the "Continue with Google" button above.',
+      type: 'warning'
+    },
+    forgotInvalidEmail: {
+      message: 'Please enter a valid email address above first.',
+      type: 'warning'
+    },
+    forgotGmailAccount: {
+      message: 'You cannot reset the password of a Gmail account using this form.',
+      type: 'danger'
+    },
+    forgotSuccess: {
+      message: 'If the email address is registered, please check your inbox for a link to reset your password.',
+      type: 'success'
+    },
+    forgotNetworkError: {
+      message: 'Network error. Please try again.',
+      type: 'danger'
+    },
+    voteNotLoggedIn: {
+      message: 'You must be logged in to vote!',
+      type: 'warning'
+    },
+    voteRateLimit: {
+      message: "You're voting too fast! Please wait a moment.",
+      type: 'primary'
+    },
+    voteError: {
+      message: 'Error submitting vote.',
+      type: 'warning'
+    },
+    voteNetworkError: {
+      message: 'Network error—please try again.',
+      type: 'warning'
+    },
+    googleSigninError: {
+      message: 'Google sign-in failed.',
+      type: 'danger'
+    },
+    googleSigninNetworkError: {
+      message: 'Network error during Google sign-in.',
+      type: 'danger'
+    }
+  };
+
+  let currentAlert = null;
+  let alertTimer   = null;
+  function showAlert(key, overrides={}){
+    const cfg = { ...defaultConfig, ...(configs[key]||{}), ...overrides };
+    const container = document.getElementById('alert-container');
+    if(!container || !cfg.message) return;
+
+    if(currentAlert){
+      currentAlert.querySelector('.alert-body').innerHTML = cfg.message;
+      resetTimer();
+      return;
+    }
+    const alertDiv = document.createElement('div');
+    alertDiv.className = `alert alert-${cfg.type}` +
+      (cfg.dismissable ? ' alert-dismissible' : '') +
+      (cfg.fade ? ' fade' : '');
+    alertDiv.setAttribute('role','alert');
+    alertDiv.setAttribute('data-bs-theme','dark');
+    alertDiv.innerHTML = `<span class="alert-body">${cfg.message}</span>`;
+    if(cfg.dismissable){
+      alertDiv.innerHTML += '<button type="button" class="btn-close btn-close-white" aria-label="Close"></button>';
+    }
+    container.append(alertDiv);
+    currentAlert = alertDiv;
+    if(cfg.fade) requestAnimationFrame(()=>alertDiv.classList.add('show'));
+
+    function dismiss(){
+      if(cfg.fade){
+        alertDiv.classList.remove('show');
+        alertDiv.addEventListener('transitionend',()=>{
+          if(alertDiv.parentElement) alertDiv.remove();
+          if(currentAlert===alertDiv) currentAlert=null;
+        },{once:true});
+      } else {
+        if(alertDiv.parentElement) alertDiv.remove();
+        if(currentAlert===alertDiv) currentAlert=null;
+      }
+      clearTimeout(alertTimer);
+    }
+    if(cfg.dismissable){
+      alertDiv.querySelector('.btn-close').addEventListener('click', dismiss);
+    }
+    function resetTimer(){
+      clearTimeout(alertTimer);
+      if(cfg.autoDismiss) alertTimer=setTimeout(dismiss,cfg.timeout);
+    }
+    resetTimer();
+  }
+
+  let currentModalAlert = null;
+  let modalAlertTimer   = null;
+  function showModalAlert(key, overrides={}){
+    const cfg = { ...defaultConfig, ...(configs[key]||{}), ...overrides };
+    if(!cfg.message) return;
+    if(currentModalAlert){
+      clearTimeout(modalAlertTimer);
+      currentModalAlert.remove();
+      currentModalAlert=null;
+    }
+    const dialog = document.querySelector('#authModal .modal-dialog');
+    if(!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    const alertDiv = document.createElement('div');
+    alertDiv.className = `alert alert-${cfg.type}` +
+      (cfg.dismissable ? ' alert-dismissible' : '') +
+      (cfg.fade ? ' fade' : '');
+    alertDiv.setAttribute('role','alert');
+    alertDiv.setAttribute('data-bs-theme','dark');
+    alertDiv.style.position='absolute';
+    alertDiv.style.top=`${rect.bottom + 8}px`;
+    alertDiv.style.left=`${rect.left}px`;
+    alertDiv.style.width=`${rect.width}px`;
+    alertDiv.style.zIndex='1060';
+    alertDiv.innerHTML = cfg.message;
+    if(cfg.dismissable){
+      alertDiv.innerHTML += '<button type="button" class="btn-close btn-close-white" aria-label="Close"></button>';
+    }
+    document.body.append(alertDiv);
+    currentModalAlert=alertDiv;
+    if(cfg.fade) requestAnimationFrame(()=>alertDiv.classList.add('show'));
+
+    function dismiss(){
+      if(cfg.fade){
+        alertDiv.classList.remove('show');
+        alertDiv.addEventListener('transitionend',()=>{
+          if(alertDiv.parentElement) alertDiv.remove();
+        },{once:true});
+      } else {
+        if(alertDiv.parentElement) alertDiv.remove();
+      }
+      currentModalAlert=null;
+      clearTimeout(modalAlertTimer);
+    }
+    if(cfg.dismissable){
+      alertDiv.querySelector('.btn-close').addEventListener('click', dismiss);
+    }
+    if(cfg.autoDismiss){
+      modalAlertTimer=setTimeout(dismiss,cfg.timeout);
+    }
+  }
+
+  window.Alerts = {
+    show: showAlert,
+    showModal: showModalAlert,
+    config: configs
+  };
+  // Backward compatibility
+  window.showAlert = showAlert;
+  window.showModalAlert = showModalAlert;
+})();

--- a/js/search.js
+++ b/js/search.js
@@ -28,9 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
       icon.addEventListener('click', e => {
         e.stopPropagation();
         if (!window.isLoggedIn) {
-          if (typeof showAlert === 'function') {
-            showAlert('You must be logged in to vote!', 'warning');
-          }
+          Alerts.show('voteNotLoggedIn');
           return;
         }
         const type      = icon.dataset.voteType;
@@ -48,9 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(res => res.status === 429 ? Promise.reject('rate_limit') : res.json())
         .then(data => {
           if (!data.success) {
-            if (typeof showAlert === 'function') {
-              showAlert(data.error || 'Error submitting vote.', 'warning');
-            }
+            Alerts.show('voteError', { message: data.error || Alerts.config.voteError.message });
             return;
           }
           const k     = data.kbm;
@@ -73,11 +69,9 @@ document.addEventListener('DOMContentLoaded', () => {
         })
         .catch(err => {
           if (err === 'rate_limit') {
-            if (typeof showAlert === 'function') {
-              showAlert("You're voting too fast! Please wait a moment.", 'primary');
-            }
-          } else if (typeof showAlert === 'function') {
-            showAlert('Network error—please try again.', 'warning');
+            Alerts.show('voteRateLimit');
+          } else {
+            Alerts.show('voteNetworkError');
           }
         });
       });


### PR DESCRIPTION
## Summary
- centralize frontend alert behavior and text in `alerts.js`
- rework `script.js`, `search.js`, and `index.php` to use the alert manager
- wire the new file before other scripts

## Testing
- `php -l index.php`
- `php -l reset_password.php`
- `php -l forgot_password.php`
- `node --check js/alerts.js`
- `node --check js/script.js`
- `node --check js/search.js`


------
https://chatgpt.com/codex/tasks/task_e_6872b7d581d0832d8e0d908e62d36770