### PR TITLE
Use shared alert helper on reset password page

### DIFF
--- a/reset_password.php
+++ b/reset_password.php
@@ -45,7 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$invalidTok) {
         $alertKeys[] = 'resetPasswordTooShort';
     }
     if ($newPass !== $confirm) {
-        $alertKeys[] = 'resetPasswordMismatch'
+        $alertKeys[] = 'resetPasswordMismatch';
     }
 
     if (empty($alertKeys)) {
@@ -63,12 +63,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$invalidTok) {
     }
 }
 
-$pageAlerts = null;
-if ($success) {
-  $pageAlerts = ['keys' => ['resetSuccess']];
-} elseif (!empty($alertKeys)) {
-  $pageAlerts = ['keys' => array_values(array_unique($alertKeys))];
-}
+$uniqueKeys = array_values(array_unique($alertKeys));
+$pageAlerts = $uniqueKeys ? ['keys' => $uniqueKeys] : null;
+
 $showForm = !$success && !$invalidTok;
 ?>
 <!DOCTYPE html>
@@ -116,12 +113,17 @@ $showForm = !$success && !$invalidTok;
 <script src="js/alerts.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    if (window.pageAlerts && Array.isArray(window.pageAlerts.keys) && window.pageAlerts.keys.length) {
-      if (window.pageAlerts.keys.length === 1) {
-        Alerts.show(window.pageAlerts.keys[0]);
-      } else {
-        Alerts.showFromKeys(window.pageAlerts.keys);
-      }
+    const alertData = window.pageAlerts;
+    const keys = alertData && Array.isArray(alertData.keys) ? alertData.keys : [];
+
+    if (!keys.length || typeof Alerts === 'undefined') {
+      return;
+    }
+
+    if (keys.length === 1) {
+      Alerts.show(keys[0]);
+    } else {
+      Alerts.showFromKeys(keys);
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- remove the inline reset-password alert configuration from reset_password.php
- expose reset-password states through `window.pageAlerts` so the existing helpers in js/alerts.js render the appropriate alert
- trigger Alerts helpers on load to surface any queued messages

## Testing
- php -l reset_password.php

------
https://chatgpt.com/codex/tasks/task_e_68ed4a96d274832d85f1a80a7c6538ab