### PR TITLE
Add email capture flow for Steam authentication

### DIFF
--- a/forgot_password.php
+++ b/forgot_password.php
@@ -19,10 +19,17 @@ if (preg_match('/@gmail\.com$/i', $email)) {
 }
 
 try {
-    // 3) Lookup user_id by email
-    $stmt = $pdo->prepare("SELECT id FROM users WHERE email = ? LIMIT 1");
+    // 3) Lookup user by email
+    $stmt = $pdo->prepare("SELECT id, steam_id FROM users WHERE email = ? LIMIT 1");
     $stmt->execute([$email]);
-    $userId = $stmt->fetchColumn();
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($user && !empty($user['steam_id'])) {
+        echo json_encode(['success' => false, 'error' => 'steam_linked']);
+        exit;
+    }
+
+    $userId = $user['id'] ?? null;
 
     if ($userId) {
         // 4) Rate limit: no more than 3 requests per hour

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -70,6 +70,12 @@ const configs = {
     type: 'danger'
   },
 
+  // When the email entered for password reset belongs to a Steam-linked account
+  forgotSteamAccount: {
+    message: 'This email address is linked to a Steam account, so there is no password to reset. Please sign in with Steam instead.',
+    type: 'warning'
+  },
+
   // When a user successfully initiates a password reset
   forgotSuccess: {
     message: 'If the email address is registered, please check your inbox for a link to reset your password.',

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -120,7 +120,13 @@ const configs = {
 
   // Steam email mismatch with account
   steamEmailMismatch: {
-    message: 'The provided email is already associated with a different account.',
+    message: 'The provided email address is already associated with a different Steam account.',
+    type: 'danger'
+  },
+
+  // Steam account already registered with another email
+  steamAlreadyRegistered: {
+    message: 'This Steam account is already registered with a different email address.',
     type: 'danger'
   },
 

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -46,6 +46,12 @@ const configs = {
     type: 'danger'
   },
 
+  // Invalid CSRF during authentication
+  authInvalidCsrf: {
+    message: 'Invalid CSRF token. Please refresh the page and try again.',
+    type: 'danger'
+  },
+
   // When a user has an email address ending in @gmail.com entered in the form and clicks the "Reset Password" link
   forgotGmailAccount: {
     message: 'You cannot reset the password of a Gmail account using this form.',
@@ -98,6 +104,30 @@ const configs = {
   googleSigninServerError: {
     message: 'A server error occurred. Please try again.',
     type: 'danger'
+  },
+
+  // Steam email validation network error
+  steamEmailNetworkError: {
+    message: 'Network error verifying your email. Please try again.',
+    type: 'danger'
+  },
+
+  // Steam sign-in failure
+  steamSigninFailed: {
+    message: 'Steam sign-in failed. Please try again.',
+    type: 'danger'
+  },
+
+  // Steam email mismatch with account
+  steamEmailMismatch: {
+    message: 'The provided email is already associated with a different account.',
+    type: 'danger'
+  },
+
+  // Missing email for Steam flow
+  steamEmailRequired: {
+    message: 'Please provide a valid email address before continuing with Steam.',
+    type: 'warning'
   },
 
   // When a user has an email address ending in @gmail.com entered in the form and clicks the "Login" or "Register" buttons

--- a/js/script.js
+++ b/js/script.js
@@ -126,7 +126,11 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ email })
       })
       .then(res => res.json())
-      .then(() => {
+      .then(data => {
+        if (data && data.success === false && data.error === 'steam_linked') {
+          Alerts.showModal('forgotSteamAccount');
+          return;
+        }
         Alerts.showModal('forgotSuccess');
       })
       .catch(() => {

--- a/steam_callback.php
+++ b/steam_callback.php
@@ -2,6 +2,11 @@
 require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
+$pendingEmail = trim($_SESSION['steam_email'] ?? '');
+$expectedUserId = isset($_SESSION['steam_email_expected_user_id'])
+    ? (int) $_SESSION['steam_email_expected_user_id']
+    : null;
+
 $hostFromEnv = '';
 $googleRedirect = $_ENV['GOOGLE_REDIRECT_URI'] ?? getenv('GOOGLE_REDIRECT_URI') ?: '';
 
@@ -43,25 +48,84 @@ if (! $oid->mode) {
 if ($oid->mode !== 'cancel' && $oid->validate()) {
     $steamId = basename($oid->identity); // The final path segment is the 64-bit SteamID
 
-    $pdo->beginTransaction();
+    try {
+        $pdo->beginTransaction();
 
-    $stmt = $pdo->prepare('SELECT id FROM users WHERE steam_id = ? LIMIT 1');
-    $stmt->execute([$steamId]);
-    $userId = $stmt->fetchColumn();
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE steam_id = ? LIMIT 1');
+        $stmt->execute([$steamId]);
+        $userId = $stmt->fetchColumn();
 
-    if (! $userId) {
-        $ins = $pdo->prepare('INSERT INTO users (steam_id, created_at) VALUES (?, NOW())');
-        $ins->execute([$steamId]);
-        $userId = $pdo->lastInsertId();
+        if (! $userId) {
+            if ($pendingEmail !== '') {
+                $emailCheck = $pdo->prepare('SELECT id FROM users WHERE email = ? LIMIT 1');
+                $emailCheck->execute([$pendingEmail]);
+                $conflictId = $emailCheck->fetchColumn();
+                if ($conflictId && (! $expectedUserId || (int) $conflictId !== $expectedUserId)) {
+                    throw new RuntimeException('steam_email_conflict');
+                }
+            }
+
+            $ins = $pdo->prepare('INSERT INTO users (steam_id, email, created_at) VALUES (?, ?, NOW())');
+            $ins->execute([$steamId, $pendingEmail !== '' ? $pendingEmail : null]);
+            $userId = $pdo->lastInsertId();
+        } else {
+            if ($expectedUserId && $expectedUserId !== (int) $userId) {
+                throw new RuntimeException('steam_email_conflict');
+            }
+
+            if ($pendingEmail !== '') {
+                $conflictCheck = $pdo->prepare('SELECT id FROM users WHERE email = ? AND id <> ? LIMIT 1');
+                $conflictCheck->execute([$pendingEmail, $userId]);
+                if ($conflictCheck->fetch()) {
+                    throw new RuntimeException('steam_email_conflict');
+                }
+
+                $upd = $pdo->prepare('UPDATE users SET email = ? WHERE id = ?');
+                $upd->execute([$pendingEmail, $userId]);
+            }
+        }
+
+        $pdo->commit();
+    } catch (RuntimeException $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        unset($_SESSION['steam_email'], $_SESSION['steam_email_expected_user_id']);
+        $_SESSION['flash'] = [
+            'alerts' => [
+                'keys'          => ['steamEmailMismatch'],
+                'mode'          => 'modal',
+                'openAuthModal' => true,
+            ],
+        ];
+        header('Location: index.php#authModal');
+        exit;
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        error_log('Steam callback failed: ' . $e->getMessage());
+        unset($_SESSION['steam_email'], $_SESSION['steam_email_expected_user_id']);
+        $_SESSION['flash'] = [
+            'alerts' => [
+                'keys'          => ['steamSigninFailed'],
+                'mode'          => 'modal',
+                'openAuthModal' => true,
+            ],
+        ];
+        header('Location: index.php#authModal');
+        exit;
     }
 
-    $pdo->commit();
+    unset($_SESSION['steam_email'], $_SESSION['steam_email_expected_user_id']);
 
     session_regenerate_id(true);
     $_SESSION['user_id'] = $userId;
     header('Location: index.php');
     exit;
 }
+
+unset($_SESSION['steam_email'], $_SESSION['steam_email_expected_user_id']);
 
 $_SESSION['flash'] = ['alerts' => ['keys' => ['steamSigninFailed'], 'mode' => 'modal']];
 header('Location: index.php#authModal');

--- a/steam_email_validate.php
+++ b/steam_email_validate.php
@@ -1,0 +1,60 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'alertKey' => 'steamSigninFailed']);
+    exit;
+}
+
+$rawInput = file_get_contents('php://input');
+$decoded  = json_decode($rawInput, true);
+
+if (!is_array($decoded)) {
+    $decoded = $_POST;
+}
+
+$csrfToken = $decoded['csrf_token'] ?? '';
+if ($csrfToken === '' || $csrfToken !== ($_SESSION['csrf_token'] ?? '')) {
+    echo json_encode(['success' => false, 'alertKey' => 'authInvalidCsrf']);
+    exit;
+}
+
+$email = trim($decoded['email'] ?? '');
+if ($email === '' || ! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    echo json_encode(['success' => false, 'alertKey' => 'authInvalidEmail']);
+    exit;
+}
+
+$lowerEmail = strtolower($email);
+if (str_ends_with($lowerEmail, '@gmail.com')) {
+    echo json_encode(['success' => false, 'alertKey' => 'loginGmailBlock']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('SELECT id, steam_id FROM users WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+} catch (Throwable $e) {
+    error_log('Steam email validation failed: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'alertKey' => 'steamSigninFailed']);
+    exit;
+}
+
+if ($existing && empty($existing['steam_id'])) {
+    echo json_encode(['success' => false, 'alertKey' => 'authEmailExists']);
+    exit;
+}
+
+if ($existing && !empty($existing['steam_id'])) {
+    $_SESSION['steam_email_expected_user_id'] = (int)$existing['id'];
+} else {
+    unset($_SESSION['steam_email_expected_user_id']);
+}
+
+$_SESSION['steam_email'] = $email;
+
+echo json_encode(['success' => true]);
+exit;


### PR DESCRIPTION
## Summary
- prompt Steam users for an email address before redirecting and reuse the existing alert system when validation fails
- validate and persist the collected email on the server during the Steam login handshake so the address is stored with the Steam user record
- add alert messages to cover the new Steam email flow states

## Testing
- php -l index.php
- php -l steam_login.php
- php -l steam_callback.php
- php -l steam_email_validate.php

------
https://chatgpt.com/codex/tasks/task_e_68f28067ed94832dbfe4b4ed5ea751f9